### PR TITLE
Fix single responsability principle violation via Adapter design pattern

### DIFF
--- a/src/main/java/bogatu/api/apiquest/controllers/DefaultAPIs.java
+++ b/src/main/java/bogatu/api/apiquest/controllers/DefaultAPIs.java
@@ -1,6 +1,7 @@
 package bogatu.api.apiquest.controllers;
 
 import bogatu.api.apiquest.dtos.API.APIDto;
+import bogatu.api.apiquest.dtos.User.UserInfo;
 import bogatu.api.apiquest.entities.User;
 import bogatu.api.apiquest.mappers.APIMapper;
 import bogatu.api.apiquest.services.User.UserService;
@@ -57,12 +58,12 @@ public class DefaultAPIs {
     }
 
 
-    public static List<APIDto> appendDefaultApis(User user, APIMapper apiMapper){
-       return Stream.concat(user.getApiSet().stream().map(apiMapper::entityToDto),
-                        Arrays.stream(DefaultAPIs.apis).map(
-                                s -> new APIDto(s, "/api/defaultApis/" + s.substring(0, 1).toLowerCase() + s.substring(1), 1, true, null, null)
-                        ))
-                .toList();
+    public static void appendDefaultApis(Set<? super APIDto> apis){
+       apis.addAll(
+               Arrays.stream(DefaultAPIs.apis).map(
+                       s -> new APIDto(s, "/api/defaultApis/" + s.substring(0, 1).toLowerCase() + s.substring(1), 1, true, null, null)
+               ).toList()
+       );
     }
 
 

--- a/src/main/java/bogatu/api/apiquest/dtos/User/UserInfo.java
+++ b/src/main/java/bogatu/api/apiquest/dtos/User/UserInfo.java
@@ -25,8 +25,7 @@ import java.util.Set;
 public class UserInfo {
 
     private int id;
-    @JsonProperty("username")
-    private String apiQuestUsername;
+    private String username;
     private String email;
     private int score;
     @JsonProperty("type")

--- a/src/main/java/bogatu/api/apiquest/dtos/User/UserRegistrationRequest.java
+++ b/src/main/java/bogatu/api/apiquest/dtos/User/UserRegistrationRequest.java
@@ -10,8 +10,7 @@ import java.time.format.DateTimeFormatter;
 @Builder
 public record UserRegistrationRequest (@NotNull
                                        @Size(min = 5)
-                                       @JsonProperty("username")
-                                       String apiQuestUsername,
+                                       String username,
                                        @NotNull @Pattern(
                                                regexp = "^(?=.*[A-Za-z])(?=.*\\d).{10,}$",
                                                message = "The password must have min length 10 " +

--- a/src/main/java/bogatu/api/apiquest/dtos/User/UserRegistrationResponse.java
+++ b/src/main/java/bogatu/api/apiquest/dtos/User/UserRegistrationResponse.java
@@ -11,8 +11,7 @@ import java.time.LocalDateTime;
 @Builder
 @JsonPropertyOrder({"id", "username", "email", "createdAt"})
 public record UserRegistrationResponse(int id,
-                                       @JsonProperty("username")
-                                       String apiQuestUsername,
+                                       String username,
                                        String email,
                                        @JsonFormat(pattern = "dd MMM, YYYY 'at' HH:mm")
                                        @JsonProperty("registrationTime")

--- a/src/main/java/bogatu/api/apiquest/dtos/User/UserUpdateDTO.java
+++ b/src/main/java/bogatu/api/apiquest/dtos/User/UserUpdateDTO.java
@@ -8,8 +8,7 @@ import java.time.LocalDateTime;
 
 public record UserUpdateDTO(@JsonProperty(access = JsonProperty.Access.READ_ONLY) Integer id,
                             @Size(min = 5)
-                            @JsonProperty("username")
-                            String apiQuestUsername,
+                            String username,
                             @Pattern(
                                     regexp = "^(?=.*[A-Za-z])(?=.*\\d).{10,}$",
                                     message = "The password must have min length 10 " +

--- a/src/main/java/bogatu/api/apiquest/entities/User.java
+++ b/src/main/java/bogatu/api/apiquest/entities/User.java
@@ -27,15 +27,14 @@ import java.util.Set;
 @Setter
 @AllArgsConstructor
 @SuperBuilder
-public class User extends GenericEntity implements UserDetails {
+public class User extends GenericEntity{
 
     @SequenceGenerator(name = "user_id_generator", sequenceName = "users_id_seq", allocationSize = 1)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "user_id_generator")
     @Column(columnDefinition = "BIGSERIAL")
     @Id
     private int id;
-    @Column(name = "username")
-    private String apiQuestUsername;
+    private String username;
     private String email;
     private String password;
     private int score;
@@ -56,45 +55,11 @@ public class User extends GenericEntity implements UserDetails {
     private Set<API> apiSet = new HashSet<>();
 
 
-
     @Override
     public boolean equals(Object o){
         if(!(o instanceof User u)) return false;
 
         return this.id == u.id
                 && this.email.equals(u.email);
-    }
-
-
-    @Override
-    public String getUsername(){
-        return this.email;
-    }
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Set.of(
-                new SimpleGrantedAuthority(role.getName())
-        );
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
     }
 }

--- a/src/main/java/bogatu/api/apiquest/mappers/APIMapper.java
+++ b/src/main/java/bogatu/api/apiquest/mappers/APIMapper.java
@@ -11,5 +11,10 @@ import org.mapstruct.Mapper;
 public interface APIMapper {
 
     API dtoToEntity(APIDto apiRegistrationRequest);
-    APIDto entityToDto(API api);
+    default APIDto entityToDto(API entity){
+        return new APIDto(
+                entity.getName(), entity.getEndpoint(), entity.getScore(), entity.isDefault(),
+                entity.getCreatedAt(), entity.getUpdatedAt()
+                );
+    }
 }

--- a/src/main/java/bogatu/api/apiquest/mappers/UserMapper.java
+++ b/src/main/java/bogatu/api/apiquest/mappers/UserMapper.java
@@ -1,9 +1,12 @@
 package bogatu.api.apiquest.mappers;
 
+import bogatu.api.apiquest.dtos.API.APIDto;
 import bogatu.api.apiquest.dtos.User.*;
 import bogatu.api.apiquest.entities.Role;
 import bogatu.api.apiquest.entities.User;
 import org.mapstruct.Mapper;
+
+import java.util.stream.Collectors;
 
 @Mapper
 public interface UserMapper {
@@ -11,14 +14,30 @@ public interface UserMapper {
     User dtoRequestToEntity(UserRegistrationRequest userRegistrationRequest);
     UserUpdateDTO entityToUpdateDto(User user);
     User updateDtoToEntity(UserUpdateDTO userUpdateDTO);
-    UserInfo entityToUserInfo(User user);
-    User userInfoToEntity(UserInfo userInfo);
-    default String map(Role role){
-        return role.getName().substring(5);
-    }
+//    UserInfo entityToUserInfo(User user);
 
-    default Role map(String role){
-        int id = role.equals("ADMIN") ? 1 : (role.equals("USER") ? 2 : 3);
-        return new Role(id, "ROLE_".concat(role), null);
+    default UserInfo entityToUserInfo(User entity){
+        return UserInfo.builder()
+                .email(entity.getEmail())
+                .username(entity.getUsername())
+                .id(entity.getId())
+                .score(entity.getScore())
+                .role(entity.getRole().getName().substring(5))
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .apiSet(
+                        entity.getApiSet()
+                                .stream()
+                                .map(a -> new APIDto(
+                                        a.getName(),
+                                        a.getEndpoint(),
+                                        a.getScore(),
+                                        a.isDefault(),
+                                        a.getCreatedAt(),
+                                        a.getUpdatedAt()
+                                ))
+                                .collect(Collectors.toSet())
+                )
+                .build();
     }
 }

--- a/src/main/java/bogatu/api/apiquest/security/SecurityConfig.java
+++ b/src/main/java/bogatu/api/apiquest/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package bogatu.api.apiquest.security;
 
 
+import bogatu.api.apiquest.security.details.SecurityUser;
 import bogatu.api.apiquest.security.filters.JWTGeneratorFilter;
 import bogatu.api.apiquest.security.filters.JWTValidatorFilter;
 import bogatu.api.apiquest.exceptions.UserNotFoundException;
@@ -49,8 +50,10 @@ public class SecurityConfig{
     @Bean
     UserDetailsService userDetailsService(UserDAO userDAO){
         return u ->
-            userDAO.findUserByEmail(u).orElseThrow(
-                    () -> new UserNotFoundException("Not found")
+            new SecurityUser(
+                    userDAO.findUserByEmail(u).orElseThrow(
+                            () -> new UserNotFoundException("Not found")
+                    )
             );
     }
 

--- a/src/main/java/bogatu/api/apiquest/security/details/SecurityUser.java
+++ b/src/main/java/bogatu/api/apiquest/security/details/SecurityUser.java
@@ -1,0 +1,57 @@
+package bogatu.api.apiquest.security.details;
+
+import bogatu.api.apiquest.entities.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Set;
+
+@RequiredArgsConstructor
+public class SecurityUser implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Set.of(
+                new SimpleGrantedAuthority(user.getRole().getName())
+        );
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public int getScore(){
+        return user.getScore();
+    }
+}

--- a/src/main/java/bogatu/api/apiquest/security/providers/APIQuestAuthProvider.java
+++ b/src/main/java/bogatu/api/apiquest/security/providers/APIQuestAuthProvider.java
@@ -2,6 +2,8 @@ package bogatu.api.apiquest.security.providers;
 
 import bogatu.api.apiquest.entities.User;
 import bogatu.api.apiquest.repositories.User.UserDAO;
+import bogatu.api.apiquest.security.details.SecurityUser;
+import bogatu.api.apiquest.services.User.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -31,7 +33,7 @@ public class APIQuestAuthProvider implements AuthenticationProvider {
                 email, null, userDetails.getAuthorities()
         );
 
-        auth.setDetails(((User) userDetails).getScore());
+        auth.setDetails(((SecurityUser) userDetails).getScore());
 
         return auth;
     }

--- a/src/main/java/bogatu/api/apiquest/security/services/JwtService.java
+++ b/src/main/java/bogatu/api/apiquest/security/services/JwtService.java
@@ -4,6 +4,7 @@ import bogatu.api.apiquest.documents.RefreshToken;
 import bogatu.api.apiquest.entities.User;
 import bogatu.api.apiquest.repositories.RefreshToken.RefreshTokenRepository;
 import bogatu.api.apiquest.repositories.User.UserDAO;
+import bogatu.api.apiquest.security.details.SecurityUser;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -96,7 +97,8 @@ public class JwtService {
         String username = claims.get("username", String.class);
 
         userDAO.findUserByEmail(username).ifPresentOrElse(
-                u -> {
+                fu -> {
+                    var u = new SecurityUser(fu);
                     var auth = new UsernamePasswordAuthenticationToken(username, null, u.getAuthorities());
                     refreshTokenRepository.findById(tokenValue.substring(BEARER_PREFIX.length()))
                                     .ifPresentOrElse(

--- a/src/main/java/bogatu/api/apiquest/services/API/APIServiceImpl.java
+++ b/src/main/java/bogatu/api/apiquest/services/API/APIServiceImpl.java
@@ -53,7 +53,16 @@ public class APIServiceImpl implements APIService{
 
     public List<APIDto> getMyAPIs(Authentication authentication){
         User user = userDAO.findUserByEmail(authentication.getName()).orElseThrow();
-        return DefaultAPIs.appendDefaultApis(user, apiMapper);
+        user.getApiSet().forEach(a -> System.out.print(a.isDefault() + " "));
+        System.out.println("-".repeat(20));
+        var userAPIs = user.getApiSet()
+                .stream()
+                .map(apiMapper::entityToDto)
+                .collect(Collectors.toSet());
+        System.out.println(userAPIs);
+        DefaultAPIs.appendDefaultApis(userAPIs);
+
+        return List.copyOf(userAPIs);
     }
 
     public List<APIDto> getAllAPIs(){

--- a/src/main/java/bogatu/api/apiquest/services/User/UserServiceImpl.java
+++ b/src/main/java/bogatu/api/apiquest/services/User/UserServiceImpl.java
@@ -88,7 +88,7 @@ public class UserServiceImpl implements UserService{
     public UserUpdateDTO updateUser(UserUpdateDTO userUpdateDTO, int id){
         User foundUser = userDAO.findUserById(id).orElseThrow(() -> new UserNotFoundException(id + " not found"));
 
-        Stream.of(userUpdateDTO.apiQuestUsername(), userUpdateDTO.email(), userUpdateDTO.password())
+        Stream.of(userUpdateDTO.username(), userUpdateDTO.email(), userUpdateDTO.password())
                 .filter(Objects::nonNull)
                 .findAny()
                 .orElseThrow(() -> new RequestValidationException("Empty body provided"));
@@ -99,7 +99,7 @@ public class UserServiceImpl implements UserService{
             throw new DuplicateException(userUpdateDTO.email() + "already taken");
 
         if(userUpdateDTO.email() != null) foundUser.setEmail(userUpdateDTO.email());
-        if(userUpdateDTO.apiQuestUsername() != null) foundUser.setApiQuestUsername(userUpdateDTO.apiQuestUsername());
+        if(userUpdateDTO.username() != null) foundUser.setUsername(userUpdateDTO.username());
         if(userUpdateDTO.password() != null) foundUser.setPassword(userUpdateDTO.password());
 
         foundUser.setUpdatedAt(LocalDateTime.now());
@@ -114,10 +114,8 @@ public class UserServiceImpl implements UserService{
                 userDAO.findUserByEmail(authentication.getName()).orElseThrow()
         );
 
-        user.getApiSet().addAll(
-                Set.copyOf(DefaultAPIs.appendDefaultApis(userMapper.userInfoToEntity(user), apiMapper))
-        );
 
+        DefaultAPIs.appendDefaultApis(user.getApiSet());
         return user;
     }
 

--- a/src/test/java/bogatu/api/apiquest/config/UserDetailsServiceTest.java
+++ b/src/test/java/bogatu/api/apiquest/config/UserDetailsServiceTest.java
@@ -4,6 +4,7 @@ import bogatu.api.apiquest.entities.User;
 import bogatu.api.apiquest.exceptions.UserNotFoundException;
 import bogatu.api.apiquest.repositories.User.UserDAO;
 import bogatu.api.apiquest.repositories.User.UserDataJPA;
+import bogatu.api.apiquest.security.details.SecurityUser;
 import bogatu.api.apiquest.tools.InstanceProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -41,8 +42,10 @@ class UserDetailsServiceTest {
     void beforeEach(){
         userDAO = Mockito.mock(UserDataJPA.class);
         underTest = u ->
-                userDAO.findUserByEmail(u).orElseThrow(
-                        () -> new UserNotFoundException("Not found")
+                new SecurityUser(
+                        userDAO.findUserByEmail(u).orElseThrow(
+                                () -> new UserNotFoundException("Not found")
+                        )
                 );
     }
 

--- a/src/test/java/bogatu/api/apiquest/mappers/UserMapperTest.java
+++ b/src/test/java/bogatu/api/apiquest/mappers/UserMapperTest.java
@@ -28,7 +28,7 @@ class UserMapperTest {
         var dtoRegResponse = userMapper.entityToDtoResponse(user);
 
         assertThat(dtoRegResponse.id()).isEqualTo(user.getId());
-        assertThat(dtoRegResponse.apiQuestUsername()).isEqualTo(user.getUsername());
+        assertThat(dtoRegResponse.username()).isEqualTo(user.getUsername());
         assertThat(dtoRegResponse.email()).isEqualTo(user.getEmail());
         assertThat(dtoRegResponse.createdAt()).isEqualTo(user.getCreatedAt());
     }

--- a/src/test/java/bogatu/api/apiquest/repositories/UserDataJPATest.java
+++ b/src/test/java/bogatu/api/apiquest/repositories/UserDataJPATest.java
@@ -38,7 +38,7 @@ class UserDataJPATest extends TestContainersTest {
 
         User toReturn = User.builder()
                 .id(1)
-                .apiQuestUsername(givenUser.getUsername())
+                .username(givenUser.getUsername())
                 .password(givenUser.getPassword())
                 .email(givenUser.getEmail())
                 .createdAt(givenUser.getCreatedAt())

--- a/src/test/java/bogatu/api/apiquest/tools/InstanceProvider.java
+++ b/src/test/java/bogatu/api/apiquest/tools/InstanceProvider.java
@@ -33,7 +33,7 @@ public final class InstanceProvider {
 
         public static User randomUser(){
             return User.builder()
-                    .apiQuestUsername(faker.name().username())
+                    .username(faker.name().username())
                     .password(faker.internet().password(true))
                     .email(faker.internet().emailAddress())
                     .createdAt(LocalDateTime.now())
@@ -45,7 +45,7 @@ public final class InstanceProvider {
         public static UserInfo randomUserInfo(){
             return UserInfo
                     .builder()
-                    .apiQuestUsername(faker.name().username())
+                    .username(faker.name().username())
                     .email(faker.internet().emailAddress())
                     .createdAt(LocalDateTime.now())
                     .build();
@@ -54,7 +54,7 @@ public final class InstanceProvider {
 
         public static UserRegistrationRequest randomRequest(){
             return UserRegistrationRequest.builder()
-                    .apiQuestUsername(faker.name().username())
+                    .username(faker.name().username())
                     .password(faker.internet().password())
                     .email(faker.internet().emailAddress())
                     .build();
@@ -65,7 +65,7 @@ public final class InstanceProvider {
             return UserRegistrationResponse
                     .builder()
                     .id(new Random().nextInt())
-                    .apiQuestUsername(faker.name().username())
+                    .username(faker.name().username())
                     .email(faker.internet().emailAddress())
                     .createdAt(LocalDateTime.now())
                     .build();


### PR DESCRIPTION
The User entity class was also implementing the UserDetails interface.
Being an entity(a class managed by JPA) is already a responsibility, hence implementing the UserDetails, which means the class is also an important component in the Authentication/Authorization flow in the Spring Security Architecture, violated the Single Responsibility Principle. I managed to fix this by using the adapter design pattern. I created the SecurityUser class that wraps the User class and implements the UserDetails interface.